### PR TITLE
Support user input that doesn't match `kind` partially

### DIFF
--- a/explorer_test.go
+++ b/explorer_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	openapi_v2 "github.com/google/gnostic/openapiv2"
@@ -121,7 +120,6 @@ FIELDS:
 		t.Run(fmt.Sprintf(`Explain "%s"`, tt.inputFieldPath), func(t *testing.T) {
 			e, err := NewExplorer(
 				tt.inputFieldPath,
-				strings.ToLower(tt.gvk.Kind),
 				openAPIResources,
 				tt.gvk,
 			)
@@ -172,4 +170,30 @@ func fetchOpenAPIResources(t *testing.T) openapi.Resources {
 		return nil
 	}
 	return r
+}
+
+func Test_fullformInputFieldPath(t *testing.T) {
+	tests := []struct {
+		inputFieldPath string
+		fullformedKind string
+		want           string
+	}{
+		{
+			inputFieldPath: "sts.spec",
+			fullformedKind: "statefulset",
+			want:           "statefulset.spec",
+		},
+		{
+			inputFieldPath: "sts",
+			fullformedKind: "statefulset",
+			want:           "statefulset",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("make %s full-formed", tt.inputFieldPath), func(t *testing.T) {
+			if got := fullformInputFieldPath(tt.inputFieldPath, tt.fullformedKind); got != tt.want {
+				t.Errorf("fullformInputFieldPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/options.go
+++ b/options.go
@@ -125,7 +125,7 @@ func (o *Options) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	e, err := NewExplorer(inputFieldPath, strings.ToLower(gvk.Kind), o.Schema, gvk)
+	e, err := NewExplorer(inputFieldPath, o.Schema, gvk)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolve https://github.com/keisku/kubectl-explore/issues/12

`kubectl-explore` didn't support the input that that doesn't match kind partially.
For example, `hpa` is the abbreviated form of `horizontalpodautoscaler`.
When we input `hpa`, this command returns the description of `hpa` even though expected open the interactive fuzzy finder.

Now, `kubectl-explore` supports this case.