### PR TITLE
Fix: fail to explain shorthand resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Download the binary from [GitHub Releases](https://github.com/keisku/kubectl-exp
 ```shell
 # Other available architectures are linux_arm64, darwin_amd64, darwin_arm64, windows_amd64.
 export ARCH=linux_amd64
-export VERSION=v0.8.0
+export VERSION=v0.8.1
 wget -O- "https://github.com/keisku/kubectl-explore/releases/download/${VERSION}/kubectl-explore_${VERSION}_${ARCH}.tar.gz" | sudo tar -xzf - -C /usr/local/bin && sudo chmod +x /usr/local/bin/kubectl-explore
 ```
 


### PR DESCRIPTION
After solving #16 by #22, `kubectl-explore` fails to explain shorthand resources like `hpa`, `deploy.spec`, `sts.*container`, etc.

This PR fix the bug.