### PR TITLE
Fix: cannot find resource when input exactly equals to resource

### DIFF
--- a/explore/options.go
+++ b/explore/options.go
@@ -141,6 +141,7 @@ func (o *Options) Complete(f cmdutil.Factory, args []string) error {
 	}
 
 	if gvar, ok := gvarMap[o.inputFieldPath]; ok {
+		o.inputFieldPathRegex = regexp.MustCompile(".*")
 		o.gvrs = []schema.GroupVersionResource{gvar.GroupVersionResource}
 		return nil
 	}

--- a/explore/options.go
+++ b/explore/options.go
@@ -140,6 +140,11 @@ func (o *Options) Complete(f cmdutil.Factory, args []string) error {
 		return err
 	}
 
+	if gvar, ok := gvarMap[o.inputFieldPath]; ok {
+		o.gvrs = []schema.GroupVersionResource{gvar.GroupVersionResource}
+		return nil
+	}
+
 	var gvar *groupVersionAPIResource
 	var resourceIdx int
 	for i := len(o.inputFieldPath); i > 0; i-- {


### PR DESCRIPTION
To fix errors when we run ...

```bash
kubectl explore pod
kubectl explore hpa
kubectl explore sts
```
