### PR TITLE
Fix `--api-version` functionality

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
         diff <(sudo microk8s kubectl explore --disable-print-path Node.*pro | tr -d '[:space:]') <(sudo microk8s kubectl explain node.spec.providerID | tr -d [':space:'])
         diff <(sudo microk8s kubectl explore --disable-print-path provider | tr -d '[:space:]') <(sudo microk8s kubectl explain node.spec.providerID | tr -d [':space:'])
         diff <(sudo microk8s kubectl explore --disable-print-path hpa.*own.*id | tr -d '[:space:]') <(sudo microk8s kubectl explain horizontalpodautoscaler.metadata.ownerReferences.uid | tr -d [':space:'])
+        diff <(sudo microk8s kubectl explore --disable-print-path --api-version autoscaling/v1 hpa.*own.*id | tr -d '[:space:]') <(sudo microk8s kubectl explain --api-version autoscaling/v1 horizontalpodautoscaler.metadata.ownerReferences.uid | tr -d [':space:'])
         diff <(sudo microk8s kubectl explore --disable-print-path csistoragecapacity.maximumVolumeSize | tr -d '[:space:]') <(sudo microk8s kubectl explain csistoragecapacity.maximumVolumeSize | tr -d [':space:'])
         diff <(sudo microk8s kubectl explore --disable-print-path csistoragecapacities.maximumVolumeSize | tr -d '[:space:]') <(sudo microk8s kubectl explain csistoragecapacity.maximumVolumeSize | tr -d [':space:'])
         diff <(sudo microk8s kubectl explore --disable-print-path CSIStorageCapacity.*VolumeSize | tr -d '[:space:]') <(sudo microk8s kubectl explain csistoragecapacity.maximumVolumeSize | tr -d [':space:'])


### PR DESCRIPTION
### What

Fixes https://github.com/keisku/kubectl-explore/issues/53, follow up with https://github.com/keisku/kubectl-explore/pull/49

### Test

Deploy fake CRDs to simulate https://github.com/keisku/kubectl-explore/issues/53.

<details><summary>test-crds.yaml</summary>

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: managedclusters.containerservice.azure.com
spec:
  group: containerservice.azure.com
  names:
    kind: ManagedCluster
    listKind: ManagedClusterList
    plural: managedclusters
    singular: managedcluster
  scope: Namespaced
  versions:
  - name: v1api20210501
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20210501storage
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20230201
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20230201storage
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20230315preview
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20230315previewstorage
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20231001
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20231001storage
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20231102preview
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20231102previewstorage
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20240402preview
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20240402previewstorage
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20240901
    served: true
    storage: false
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object
  - name: v1api20240901storage
    served: true
    storage: true
    subresources:
      status: {}
    schema:
      openAPIV3Schema:
        type: object
        properties:
          spec:
            type: object
            properties:
              location:
                type: string
              dnsPrefix:
                type: string
          status:
            type: object

```

</details>


Ensured it worked well.

```bash
./kubectl-explore --api-version containerservice.azure.com/v1api20240901 ManagedCluster
# Open an interactive shell.

./kubectl-explore --api-version containerservice.azure.com/v1api20240901 'ManagedCluster.*own.*api'
PATH: managedclusters.metadata.ownerReferences.apiVersion
GROUP:      containerservice.azure.com
KIND:       ManagedCluster
VERSION:    v1api20240901

FIELD: apiVersion <string>


DESCRIPTION:
    API version of the referent.
```